### PR TITLE
在保留全部内容的前提下将原消息转换成Component

### DIFF
--- a/src/main/java/cn/glycol/extrabot/component/Component.java
+++ b/src/main/java/cn/glycol/extrabot/component/Component.java
@@ -1,135 +1,137 @@
 package cn.glycol.extrabot.component;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
 import cn.glycol.extrabot.component.ComponentContact.Type;
 import cn.glycol.extrabot.component.ComponentRPS.RSP;
 import cn.glycol.tutils.map.ParseableHashMap;
 import lombok.ToString;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * 消息组件，内置了消息组件解析器。
- * 
+ *
  * @author Taskeren
  * @GitHub https://github.com/nitu2003/PicqBotX
  */
 @ToString
 public class Component {
+    private static final String REGEX_CQ_CODE = "(\\[CQ:.*?,.*?])";
+    private static final Pattern CQC = Pattern.compile(REGEX_CQ_CODE);
 
-	private static final Pattern CQC = Pattern.compile("(\\[).*?(\\])");
+    /**
+     * 返回解析后的组件，任何错误的数据将使用默认值，基础数据为{@code -1}，其他为{@code null}。
+     *
+     * @param message 消息原文
+     * @return 解析后的组件
+     */
+    public static Component parseComponent(String message){
+        String s0 = message.substring(1, message.length() - 1); // 去掉头尾的"[]"
+        String[] s1 = s0.split(","); // 处理成数据对，像这样：["CQ:at", "qq=123456"]
+        HashMap<String, String> map = genDataMap(s1); // 处理成Map
+        ParseableHashMap<String, String> data = new ParseableHashMap<>(map);
+        String type = data.get("CQ"); // 获取CQ码类型
+        try {
+            switch (type) {
 
-	/**
-	 * 返回解析后的组件，任何错误的数据将使用默认值，基础数据为{@code -1}，其他为{@code null}。
-	 * 
-	 * @param message 消息原文
-	 * @return 解析后的组件
-	 */
-	public static Component parseComponent(String message) {
-		if (!isCQCode(message)) {
-			return new ComponentString(message);
-		}
+                case "face":
+                    return new ComponentFace(data.getInteger("id", -1));
 
-		String s0 = message.substring(1, message.length() - 1); // 去掉头尾的"[]"
-		String[] s1 = s0.split(","); // 处理成数据对，像这样：“["CQ:at", "qq=123456"]”
-		HashMap<String, String> map = genDataMap(s1); // 处理成Map
-		ParseableHashMap<String, String> data = new ParseableHashMap<String, String>(map);
+                case "bface":
+                    return new ComponentBFace(data.getInteger("p", -1), data.get("id"));
 
-		String type = data.get("CQ"); // 获取CQ码类型
+                case "image":
+                    return new ComponentImage(data.get("file"), data.get("url"));
 
-		switch (type) {
+                case "record":
+                    return new ComponentRecord(data.get("file"), data.getBoolean("magic", false));
 
-		case "face":
-			return new ComponentFace(data.getInteger("id", -1));
+                case "at":
+                    return new ComponentAt(data.getLong("qq", -1));
 
-		case "bface":
-			return new ComponentBFace(data.getInteger("p", -1), data.get("id"));
+                case "rps":
+                    return new ComponentRPS(RSP.of(data.getInteger("type", -1)));
 
-		case "image":
-			return new ComponentImage(data.get("file"), data.get("url"));
+                case "dice":
+                    return new ComponentDice(data.getInteger("type", -1));
 
-		case "record":
-			return new ComponentRecord(data.get("file"), data.getBoolean("magic", false));
+                case "shake":
+                    return new ComponentShake();
 
-		case "at":
-			return new ComponentAt(data.getLong("qq", -1));
+                case "sign":
+                    return new ComponentSign(data.get("location"), data.get("title"), data.get("image"));
 
-		case "rps":
-			return new ComponentRPS(RSP.of(data.getInteger("type", -1)));
+                case "rich":
+                    return new ComponentRich(data.get("title"), data.get("text"), data.get("content"));
 
-		case "dice":
-			return new ComponentDice(data.getInteger("type", -1));
+                case "location":
+                    return new ComponentLocation(data.get("lat"), data.get("lon"), data.get("title"), data.get("content"), data.getInteger("style", -1));
 
-		case "shake":
-			return new ComponentShake();
-			
-		case "sign":
-			return new ComponentSign(data.get("location"), data.get("title"), data.get("image"));
-			
-		case "rich":
-			return new ComponentRich(data.get("title"), data.get("text"), data.get("content"));
-			
-		case "location":
-			return new ComponentLocation(data.get("lat"), data.get("lon"), data.get("title"), data.get("content"), data.getInteger("style", -1));
-			
-		case "contact":
-			return new ComponentContact(data.getLong("id", -1), Type.of(data.get("type")));
+                case "contact":
+                    return new ComponentContact(data.getLong("id", -1), Type.of(data.get("type")));
 
-		default:
-			return new ComponentString(message);
-		}
-	}
+                default:
+                    return new ComponentString(message);
+            }
+        } catch (Exception e) {
+            return new ComponentString(message);
+        }
+    }
 
-	/**
-	 * 返回解析后的组件列表。解析方法：{@link #parseComponent(String)}。
-	 * 
-	 * @param args 消息列表
-	 * @return 解析后组件列表
-	 */
-	public static ArrayList<Component> parseComponents(ArrayList<String> args) {
-		ArrayList<Component> components = Lists.newArrayList();
+    /**
+     * 返回解析后的组件列表。解析方法：{@link #parseComponent(String)}。
+     *
+     * @param args 消息列表
+     * @return 解析后组件列表
+     */
+    public static ArrayList<Component> parseComponents(ArrayList<String> args){
+        ArrayList<Component> components = new ArrayList<>();
 
-		for (String arg : args) {
-			int count = 0;
+        for (String arg : args) {
+            int count = 0;
 
-			Matcher matcher = CQC.matcher(arg);
+            Matcher matcher = CQC.matcher(arg);
+            int end = 0;
+            while (matcher.find()) {
+                //string before cq code
+                if(matcher.start() > end){
+                    String strBefore = arg.substring(end, matcher.start());
+                    components.add(new ComponentString(strBefore));
+                }
+                String content = matcher.group();
+                Component component = parseComponent(content);
+                components.add(component);
+                end = matcher.end();
+                count++;
+            }
+            //string after last cq code
+            if(end < arg.length()){
+                String strAfter = arg.substring(end);
+                components.add(new ComponentString(strAfter));
+                count++;
+            }
+            if(count == 0){
+                components.add(new ComponentString(arg));
+            }
 
-			while (matcher.find()) {
-				String content = matcher.group();
-				Component component = parseComponent(content);
-				components.add(component);
-				count++;
-			}
 
-			if (count == 0) {
-				components.add(new ComponentString(arg));
-			}
-		}
+        }
 
-		return components;
-	}
+        return components;
+    }
 
-	private static HashMap<String, String> genDataMap(String[] array) {
-		HashMap<String, String> map = Maps.newHashMap();
+    private static HashMap<String, String> genDataMap(String[] array){
+        HashMap<String, String> map = new HashMap<>();
 
-		for (String s : array) {
-			String[] s0 = s.split(":|=", 2);
-			if (s0.length < 2)
-				continue;
-			map.put(s0[0], s0[1]);
-		}
+        for (String s : array) {
+            String[] s0 = s.split("[:=]", 2);
+            if(s0.length < 2)
+                continue;
+            map.put(s0[0], s0[1]);
+        }
 
-		return map;
-	}
-
-	private static boolean isCQCode(String message) {
-		message = message.trim();
-		return message.startsWith("[CQ:") && message.endsWith("]");
-	}
-
+        return map;
+    }
 }

--- a/src/main/java/cn/glycol/extrabot/component/Component.java
+++ b/src/main/java/cn/glycol/extrabot/component/Component.java
@@ -83,6 +83,42 @@ public class Component {
     /**
      * 返回解析后的组件列表。解析方法：{@link #parseComponent(String)}。
      *
+     * @param s 消息
+     * @return 解析后组件列表
+     */
+    public static ArrayList<Component> parseComponents(String s){
+        ArrayList<Component> components = new ArrayList<>();
+        int count = 0;
+
+        Matcher matcher = CQC.matcher(s);
+        int end = 0;
+        while (matcher.find()) {
+            //string before cq code
+            if(matcher.start() > end){
+                String strBefore = s.substring(end, matcher.start());
+                components.add(new ComponentString(strBefore));
+            }
+            String content = matcher.group();
+            Component component = parseComponent(content);
+            components.add(component);
+            end = matcher.end();
+            count++;
+        }
+        //string after last cq code
+        if(end < s.length()){
+            String strAfter = s.substring(end);
+            components.add(new ComponentString(strAfter));
+            count++;
+        }
+        if(count == 0){
+            components.add(new ComponentString(s));
+        }
+        return components;
+    }
+
+    /**
+     * 返回解析后的组件列表。解析方法：{@link #parseComponent(String)}。
+     *
      * @param args 消息列表
      * @return 解析后组件列表
      */
@@ -90,33 +126,7 @@ public class Component {
         ArrayList<Component> components = new ArrayList<>();
 
         for (String arg : args) {
-            int count = 0;
-
-            Matcher matcher = CQC.matcher(arg);
-            int end = 0;
-            while (matcher.find()) {
-                //string before cq code
-                if(matcher.start() > end){
-                    String strBefore = arg.substring(end, matcher.start());
-                    components.add(new ComponentString(strBefore));
-                }
-                String content = matcher.group();
-                Component component = parseComponent(content);
-                components.add(component);
-                end = matcher.end();
-                count++;
-            }
-            //string after last cq code
-            if(end < arg.length()){
-                String strAfter = arg.substring(end);
-                components.add(new ComponentString(strAfter));
-                count++;
-            }
-            if(count == 0){
-                components.add(new ComponentString(arg));
-            }
-
-
+            components.addAll(parseComponents(arg));
         }
 
         return components;

--- a/src/main/java/cn/glycol/extrabot/component/Component.java
+++ b/src/main/java/cn/glycol/extrabot/component/Component.java
@@ -18,130 +18,130 @@ import java.util.regex.Pattern;
  */
 @ToString
 public class Component {
-    private static final String REGEX_CQ_CODE = "(\\[CQ:.*?,.*?])";
-    private static final Pattern CQC = Pattern.compile(REGEX_CQ_CODE);
+	private static final String REGEX_CQ_CODE = "(\\[CQ:.*?,.*?])";
+	private static final Pattern CQC = Pattern.compile(REGEX_CQ_CODE);
 
-    /**
-     * 返回解析后的组件，任何错误的数据将使用默认值，基础数据为{@code -1}，其他为{@code null}。
-     *
-     * @param message 消息原文
-     * @return 解析后的组件
-     */
-    public static Component parseComponent(String message){
-        String s0 = message.substring(1, message.length() - 1); // 去掉头尾的"[]"
-        String[] s1 = s0.split(","); // 处理成数据对，像这样：["CQ:at", "qq=123456"]
-        HashMap<String, String> map = genDataMap(s1); // 处理成Map
-        ParseableHashMap<String, String> data = new ParseableHashMap<>(map);
-        String type = data.get("CQ"); // 获取CQ码类型
-        try {
-            switch (type) {
+	/**
+	 * 返回解析后的组件，任何错误的数据将使用默认值，基础数据为{@code -1}，其他为{@code null}。
+	 *
+	 * @param message 消息原文
+	 * @return 解析后的组件
+	 */
+	public static Component parseComponent(String message) {
+		String s0 = message.substring(1, message.length() - 1); // 去掉头尾的"[]"
+		String[] s1 = s0.split(","); // 处理成数据对，像这样：["CQ:at", "qq=123456"]
+		HashMap<String, String> map = genDataMap(s1); // 处理成Map
+		ParseableHashMap<String, String> data = new ParseableHashMap<>(map);
+		String type = data.get("CQ"); // 获取CQ码类型
+		try {
+			switch (type) {
 
-                case "face":
-                    return new ComponentFace(data.getInteger("id", -1));
+			case "face":
+				return new ComponentFace(data.getInteger("id", -1));
 
-                case "bface":
-                    return new ComponentBFace(data.getInteger("p", -1), data.get("id"));
+			case "bface":
+				return new ComponentBFace(data.getInteger("p", -1), data.get("id"));
 
-                case "image":
-                    return new ComponentImage(data.get("file"), data.get("url"));
+			case "image":
+				return new ComponentImage(data.get("file"), data.get("url"));
 
-                case "record":
-                    return new ComponentRecord(data.get("file"), data.getBoolean("magic", false));
+			case "record":
+				return new ComponentRecord(data.get("file"), data.getBoolean("magic", false));
 
-                case "at":
-                    return new ComponentAt(data.getLong("qq", -1));
+			case "at":
+				return new ComponentAt(data.getLong("qq", -1));
 
-                case "rps":
-                    return new ComponentRPS(RSP.of(data.getInteger("type", -1)));
+			case "rps":
+				return new ComponentRPS(RSP.of(data.getInteger("type", -1)));
 
-                case "dice":
-                    return new ComponentDice(data.getInteger("type", -1));
+			case "dice":
+				return new ComponentDice(data.getInteger("type", -1));
 
-                case "shake":
-                    return new ComponentShake();
+			case "shake":
+				return new ComponentShake();
 
-                case "sign":
-                    return new ComponentSign(data.get("location"), data.get("title"), data.get("image"));
+			case "sign":
+				return new ComponentSign(data.get("location"), data.get("title"), data.get("image"));
 
-                case "rich":
-                    return new ComponentRich(data.get("title"), data.get("text"), data.get("content"));
+			case "rich":
+				return new ComponentRich(data.get("title"), data.get("text"), data.get("content"));
 
-                case "location":
-                    return new ComponentLocation(data.get("lat"), data.get("lon"), data.get("title"), data.get("content"), data.getInteger("style", -1));
+			case "location":
+				return new ComponentLocation(data.get("lat"), data.get("lon"), data.get("title"), data.get("content"),
+						data.getInteger("style", -1));
 
-                case "contact":
-                    return new ComponentContact(data.getLong("id", -1), Type.of(data.get("type")));
+			case "contact":
+				return new ComponentContact(data.getLong("id", -1), Type.of(data.get("type")));
 
-                default:
-                    return new ComponentString(message);
-            }
-        } catch (Exception e) {
-            return new ComponentString(message);
-        }
-    }
+			default:
+				return new ComponentString(message);
+			}
+		} catch (Exception e) {
+			return new ComponentString(message);
+		}
+	}
 
-    /**
-     * 返回解析后的组件列表。解析方法：{@link #parseComponent(String)}。
-     *
-     * @param s 消息
-     * @return 解析后组件列表
-     */
-    public static ArrayList<Component> parseComponents(String s){
-        ArrayList<Component> components = new ArrayList<>();
-        int count = 0;
+	/**
+	 * 返回解析后的组件列表。解析方法：{@link #parseComponent(String)}。
+	 *
+	 * @param s 消息
+	 * @return 解析后组件列表
+	 */
+	public static ArrayList<Component> parseComponents(String s) {
+		ArrayList<Component> components = new ArrayList<>();
+		int count = 0;
 
-        Matcher matcher = CQC.matcher(s);
-        int end = 0;
-        while (matcher.find()) {
-            //string before cq code
-            if(matcher.start() > end){
-                String strBefore = s.substring(end, matcher.start());
-                components.add(new ComponentString(strBefore));
-            }
-            String content = matcher.group();
-            Component component = parseComponent(content);
-            components.add(component);
-            end = matcher.end();
-            count++;
-        }
-        //string after last cq code
-        if(end < s.length()){
-            String strAfter = s.substring(end);
-            components.add(new ComponentString(strAfter));
-            count++;
-        }
-        if(count == 0){
-            components.add(new ComponentString(s));
-        }
-        return components;
-    }
+		Matcher matcher = CQC.matcher(s);
+		int end = 0;
+		while (matcher.find()) {
+			// string before cq code
+			if (matcher.start() > end) {
+				String strBefore = s.substring(end, matcher.start());
+				components.add(new ComponentString(strBefore));
+			}
+			String content = matcher.group();
+			Component component = parseComponent(content);
+			components.add(component);
+			end = matcher.end();
+			count++;
+		}
+		// string after last cq code
+		if (end < s.length()) {
+			String strAfter = s.substring(end);
+			components.add(new ComponentString(strAfter));
+			count++;
+		}
+		if (count == 0) {
+			components.add(new ComponentString(s));
+		}
+		return components;
+	}
 
-    /**
-     * 返回解析后的组件列表。解析方法：{@link #parseComponent(String)}。
-     *
-     * @param args 消息列表
-     * @return 解析后组件列表
-     */
-    public static ArrayList<Component> parseComponents(ArrayList<String> args){
-        ArrayList<Component> components = new ArrayList<>();
+	/**
+	 * 返回解析后的组件列表。解析方法：{@link #parseComponent(String)}。
+	 *
+	 * @param args 消息列表
+	 * @return 解析后组件列表
+	 */
+	public static ArrayList<Component> parseComponents(ArrayList<String> args) {
+		ArrayList<Component> components = new ArrayList<>();
 
-        for (String arg : args) {
-            components.addAll(parseComponents(arg));
-        }
+		for (String arg : args) {
+			components.addAll(parseComponents(arg));
+		}
 
-        return components;
-    }
+		return components;
+	}
 
-    private static HashMap<String, String> genDataMap(String[] array){
-        HashMap<String, String> map = new HashMap<>();
+	private static HashMap<String, String> genDataMap(String[] array) {
+		HashMap<String, String> map = new HashMap<>();
 
-        for (String s : array) {
-            String[] s0 = s.split("[:=]", 2);
-            if(s0.length < 2)
-                continue;
-            map.put(s0[0], s0[1]);
-        }
+		for (String s : array) {
+			String[] s0 = s.split("[:=]", 2);
+			if (s0.length < 2) continue;
+			map.put(s0[0], s0[1]);
+		}
 
-        return map;
-    }
+		return map;
+	}
 }

--- a/src/test/java/cn/glycol/extrabot/test/ComponentTest.java
+++ b/src/test/java/cn/glycol/extrabot/test/ComponentTest.java
@@ -1,0 +1,65 @@
+package cn.glycol.extrabot.test;
+
+
+import cn.glycol.extrabot.component.Component;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class ComponentTest {
+    @Test
+    public void parse(){
+        System.out.println(Component.parseComponent("[CQ: , ]"));
+        System.out.println(Component.parseComponent("Not CQ Code"));
+        System.out.println(Component.parseComponent("[CQ:face,id=14]"));
+        System.out.println(Component.parseComponent(" [CQ:image,file=1.jpg] "));
+    }
+    @Test
+    public void parseMulti(){
+        List<Component> components=Component.parseComponents(new ArrayList<>(Arrays.asList("before[CQ:face,id=14]after")));
+        for (Component component:components){
+            System.out.println(component);
+        }
+        System.out.println("///////////////");
+        components=Component.parseComponents(new ArrayList<>(Arrays.asList("together as one!")));
+        for (Component component:components){
+            System.out.println(component);
+        }
+        System.out.println("///////////////");
+        components=Component.parseComponents(new ArrayList<>(Arrays.asList(
+                "[CQ:face,id=14]Before a component[CQ:face,id=14]After a component/At the end",
+                "This String is in the array",
+                "[CQ:face,id=14]"
+        )));
+        for (Component component:components){
+            System.out.println(component);
+        }
+    }
+    @Test
+    public void speedTest(){
+        String regex_new = "(\\[CQ:.*?,.*?\\])";
+        Pattern pattern_new=Pattern.compile(regex_new);
+        Pattern pattern_old=Pattern.compile("(\\[).*?(\\])");
+
+        String s = "[CQ:face,id=14]";
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < 10000; i++) {
+            pattern_old.matcher(s);
+            isCQCode(s);
+        }
+        System.out.println("old method:" + (System.currentTimeMillis() - start));
+        start = System.currentTimeMillis();
+        for (int i = 0; i < 10000; i++) {
+            pattern_new.matcher(s);
+        }
+        System.out.println("new method:" + (System.currentTimeMillis() - start));
+    }
+
+    private boolean isCQCode(String message){
+        message = message.trim();
+        return message.startsWith("[CQ:") && message.endsWith("]");
+    }
+}


### PR DESCRIPTION
新方法匹配cq码的速度相比原方法(正则+特征字符匹配)更快。
新方法保留原消息中的全部内容，不仅是cq码。例如"before[CQ:face,id=14]after"将被解析成两个ComponentString和一个ComponentFace